### PR TITLE
Move ino file to project folder. Modify analog read to use ADC1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+libraries/
+PCB/Version1.2.b##
+.idea/

--- a/NanoLux_Stereo/NanoLux_Stereo.ino
+++ b/NanoLux_Stereo/NanoLux_Stereo.ino
@@ -89,7 +89,7 @@ int NUM_LEDS = MAX_LEDS;
 */
 #define SAMPLES             128    // Must be a power of 2  // 128 - 1024
 #define SAMPLING_FREQUENCY  8000  // Hz, must be less than 10000 due to ADC
-#define ANALOG_PIN          A0
+#define ANALOG_PIN          A2
 
 unsigned int sampling_period_us = round(1000000/SAMPLING_FREQUENCY);
 unsigned long microseconds;
@@ -188,10 +188,10 @@ void audio_analysis() {
     for(int i=0; i<SAMPLES; i++) {
         microseconds = micros();    //Overflows after around 70 minutes!
 
-        lReal[i] = analogRead(A0);
+        lReal[i] = analogRead(A2);
         lImag[i] = 0;
 
-        rReal[i] = analogRead(A1);
+        rReal[i] = analogRead(A3);
         rImag[i] = 0;
 
         while(micros() < (microseconds + sampling_period_us)){


### PR DESCRIPTION
The move of the ino file to its own folder is because the IDE really wants it there.  The actual changes to the code are in lines 92, 191, and 194.

Since we have no unit tests yet, I have no report of that. However, I did test the modified code with the hardware, and it works just as it did with the ADC2. 

NOTE: this code will only work with modified AudioLux boards. I will post a modification document soon.