### PR TITLE
Adjusted rotary encoder boundary, removed modulo for calculating pattern index

### DIFF
--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -289,15 +289,15 @@ void IRAM_ATTR readEncoderISR(){
 void setup_rotary_encoder(){
     rotaryEncoder.begin();
     rotaryEncoder.setup(readEncoderISR);
-    rotaryEncoder.setBoundaries(0, 1000, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
-    rotaryEncoder.setAcceleration(0);
+    rotaryEncoder.setBoundaries(0, NUM_PATTERNS - 1, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
+    rotaryEncoder.disableAcceleration();
 }
 
 /// @brief Calculates the pattern index the rotary encoder currently
 /// corresponds to.
 /// @returns The pattern index the encoder is set to.
 int calculate_pattern_index(){
-    return static_cast<int>(floor(rotaryEncoder.readEncoder())) % NUM_PATTERNS;
+    return static_cast<int>(floor(rotaryEncoder.readEncoder()));
 }
 
 /// @brief Returns the current state of the rotary encoder button.

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -297,7 +297,7 @@ void setup_rotary_encoder(){
 /// corresponds to.
 /// @returns The pattern index the encoder is set to.
 int calculate_pattern_index(){
-    return static_cast<int>(floor(rotaryEncoder.readEncoder()));
+    return static_cast<int>(floor(rotaryEncoder.readEncoder())) % NUM_PATTERNS;
 }
 
 /// @brief Returns the current state of the rotary encoder button.


### PR DESCRIPTION
Adjusted rotary encoder upper boundary to NUM_PATTERNS - 1 in setup_rotary_encoder.
    - Values read from the encoder will now range from 0 - 14 instead of 0 - 1000.