### PR TITLE
Rotary encoder functionality

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -382,9 +382,20 @@ void update_hardware(){
     // current pattern index.
     if (!manual_control_enabled) {
       uint8_t currentPatternIdx = loaded_patterns.pattern[0].idx;
+
+      /*
+      // print current encoder value to serial monitor
+      Serial.print("Rotary Encoder Value: ");
+      Serial.println(manual_pattern.idx);
+      */
       
       if (currentPatternIdx != manual_pattern.idx) {
         update_encoder_value(currentPatternIdx);
+        /*
+        // print the updated encoder value
+        Serial.print("Updated Encoder Value to: ");
+        Serial.println(calculate_pattern_index());
+        */
       }
     }
       

--- a/main/main.ino
+++ b/main/main.ino
@@ -375,6 +375,18 @@ void update_hardware(){
       pattern_changed = true;
       manual_control_enabled = true;
     }
+
+    // Check if the Webapp has been updated
+    // (manual_control_enabled = false)
+    // and update the rotary encoder's value to the
+    // current pattern index.
+    if (!manual_control_enabled) {
+      uint8_t currentPatternIdx = loaded_patterns.pattern[0].idx;
+      
+      if (currentPatternIdx != manual_pattern.idx) {
+        update_encoder_value(currentPatternIdx);
+      }
+    }
       
 
   #else

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -305,3 +305,8 @@ int calculate_pattern_index(){
 bool isEncoderButtonPressed(){
     return rotaryEncoder.isEncoderButtonClicked();
 }
+
+/// @brief Sets the rotary encoder's current position to a new value
+void update_encoder_value(long newValue){
+    rotaryEncoder.setEncoderValue(newValue);
+}

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -289,15 +289,15 @@ void IRAM_ATTR readEncoderISR(){
 void setup_rotary_encoder(){
     rotaryEncoder.begin();
     rotaryEncoder.setup(readEncoderISR);
-    rotaryEncoder.setBoundaries(0, 1000, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
-    rotaryEncoder.setAcceleration(0);
+    rotaryEncoder.setBoundaries(0, NUM_PATTERNS - 1, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
+    rotaryEncoder.disableAcceleration();
 }
 
 /// @brief Calculates the pattern index the rotary encoder currently
 /// corresponds to.
 /// @returns The pattern index the encoder is set to.
 int calculate_pattern_index(){
-    return static_cast<int>(floor(rotaryEncoder.readEncoder())) % NUM_PATTERNS;
+    return static_cast<int>(floor(rotaryEncoder.readEncoder()));
 }
 
 /// @brief Returns the current state of the rotary encoder button.

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -297,7 +297,7 @@ void setup_rotary_encoder(){
 /// corresponds to.
 /// @returns The pattern index the encoder is set to.
 int calculate_pattern_index(){
-    return static_cast<int>(floor(rotaryEncoder.readEncoder()));
+    return static_cast<int>(floor(rotaryEncoder.readEncoder())) % NUM_PATTERNS;
 }
 
 /// @brief Returns the current state of the rotary encoder button.

--- a/main/nanolux_util.h
+++ b/main/nanolux_util.h
@@ -23,5 +23,6 @@ void IRAM_ATTR readEncoderISR();
 void setup_rotary_encoder();
 int calculate_pattern_index();
 bool isEncoderButtonPressed();
+void update_encoder_value(long newValue);
 
 #endif

--- a/main/webServer.h
+++ b/main/webServer.h
@@ -17,7 +17,7 @@
 #define ALWAYS_PRINTF(...) Serial.printf(__VA_ARGS__)
 
 // Uncomment to use the old LittleFS web app loader.
-//#define SD_LOADER
+#define SD_LOADER
 
 #ifdef SD_LOADER
   #include "FS.h"


### PR DESCRIPTION
Includes changes to the rotary encoder setup so values only range from 0 to the number of patterns (old change).

Added update_encoder_value() to nanolux_util.h and nanolux_util.cpp.
- This allows the encoder's value to be changed to a specified new value.
- Used for syncing the rotary encoder with the web app when a new pattern is selected via the frontend.

Added logic to check if changes have been made to the web app (via API PUT requests and manual_control_enabled) and calls the new encoder functionality to update its value in main.ino (in update_hardware()).

***HAS NOT BEEN TESTED, DO NOT MERGE***