### PR TITLE
Refactored the Rotary Encoder and Fully Implemented Bidirectional Communication

### DIFF
--- a/WebApp/src/components/pattern_settings/index.js
+++ b/WebApp/src/components/pattern_settings/index.js
@@ -65,6 +65,23 @@ const PatternSettings = ({num, patterns}) => {
     }, 100);
 
 	/**
+	 * @brief Continuously poll the Nanolux device for changes to the
+	 * hardware pattern index, updates the web app UI to reflect the change.
+	 */
+	useInterval(() => {
+		if (isConnected && !updated) {
+			getPattern(num).then(newData => {
+				console.log("Fetched pattern from ESP32:", newData.idx);
+
+				if (newData.idx !== data.idx) {
+					console.log("Updating UI with new pattern:", newData.idx)
+					setData(newData);
+				}
+			});
+		}
+	}, 1000);
+
+	/**
 	 * @brief Updates a parameter in the pattern data structure with a new value.
 	 * @param ref The string reference to update in the data structure
 	 * @param value The new value to update the data structure with

--- a/WebApp/src/components/pattern_settings/index.js
+++ b/WebApp/src/components/pattern_settings/index.js
@@ -71,15 +71,15 @@ const PatternSettings = ({num, patterns}) => {
 	useInterval(() => {
 		if (isConnected && !updated) {
 			getPattern(num).then(newData => {
-				console.log("Fetched pattern from ESP32:", newData.idx);
+				//console.log("Fetched pattern from ESP32:", newData.idx);
 
 				if (newData.idx !== data.idx) {
-					console.log("Updating UI with new pattern:", newData.idx)
+					//console.log("Updating UI with new pattern:", newData.idx)
 					setData(newData);
 				}
 			});
 		}
-	}, 1000);
+	}, 200);
 
 	/**
 	 * @brief Updates a parameter in the pattern data structure with a new value.

--- a/main/api.h
+++ b/main/api.h
@@ -83,10 +83,7 @@ inline void handle_pattern_get_request(AsyncWebServerRequest* request) {
   uint8_t pattern_num = request->getParam(0)->value().toInt();
   bound_byte(&pattern_num, 0, PATTERN_LIMIT);
 
-  Pattern_Data p = manual_control_enabled ? manual_pattern : loaded_patterns.pattern[pattern_num];
-
-  Serial.println("ESP32 API: Sending Pattern Data:");
-  Serial.println("idx: " + String(p.idx) + " brightness: " + String(p.brightness) + " smoothing: " + String(p.smoothing) + " hue min/max: " + String(p.minhue) + "/" + String(p.maxhue) + " config: " + String(p.config) + " pp mode: " + String(p.postprocessing_mode));
+  Pattern_Data p = loaded_patterns.pattern[pattern_num];
 
   // Create response substrings
   String idx = String(" \"idx\": ") + p.idx;

--- a/main/api.h
+++ b/main/api.h
@@ -83,7 +83,10 @@ inline void handle_pattern_get_request(AsyncWebServerRequest* request) {
   uint8_t pattern_num = request->getParam(0)->value().toInt();
   bound_byte(&pattern_num, 0, PATTERN_LIMIT);
 
-  Pattern_Data p = loaded_patterns.pattern[pattern_num];
+  Pattern_Data p = manual_control_enabled ? manual_pattern : loaded_patterns.pattern[pattern_num];
+
+  Serial.println("ESP32 API: Sending Pattern Data:");
+  Serial.println("idx: " + String(p.idx) + " brightness: " + String(p.brightness) + " smoothing: " + String(p.smoothing) + " hue min/max: " + String(p.minhue) + "/" + String(p.maxhue) + " config: " + String(p.config) + " pp mode: " + String(p.postprocessing_mode));
 
   // Create response substrings
   String idx = String(" \"idx\": ") + p.idx;

--- a/main/main.ino
+++ b/main/main.ino
@@ -375,6 +375,31 @@ void update_hardware(){
       pattern_changed = true;
       manual_control_enabled = true;
     }
+
+    /*
+    Check if the webapp has been updated and
+    update the rotary encoder's value to the 
+    current pattern index.
+    */
+    if (!manual_control_enabled) {
+      uint8_t currentPatternIdx = loaded_patterns.pattern[0].idx;
+
+      /*
+      print current encoder value to serial monitor
+      Serial.print("Rotary Encoder Value: ");
+      Serial.println(manual_pattern.idx);
+      */
+
+      if (currentPatternIdx != manual_pattern.idx) {
+        update_encoder_value(currentPatternIdx);
+
+        /*
+        print the updated encoder value
+        Serial.print("Updated Encoder Value to: ");
+        Serial.println(calculate_pattern_index());
+        */
+      }
+    }
       
 
   #else

--- a/main/nanolux_types.h
+++ b/main/nanolux_types.h
@@ -21,7 +21,7 @@ typedef void (*SimplePatternList[])();
 //
 // When using a board with a version below 1.2, or an unmodified
 // v1.2 board, set this pin to A0.
-#define ANALOG_PIN          A3
+#define ANALOG_PIN          A2 //A3
 
 // Vowel recognition
 enum VowelSounds {
@@ -34,9 +34,9 @@ enum VowelSounds {
 };
 
 // Rotary Encoder Constants
-#define ROTARY_ENCODER_A_PIN 23
-#define ROTARY_ENCODER_B_PIN 22
-#define ROTARY_ENCODER_BUTTON_PIN 33
+#define ROTARY_ENCODER_A_PIN 27 //23
+#define ROTARY_ENCODER_B_PIN 33 //22
+#define ROTARY_ENCODER_BUTTON_PIN 32 //33
 #define ROTARY_ENCODER_VCC_PIN -1
 #define ROTARY_ENCODER_STEPS 4
 
@@ -60,7 +60,7 @@ enum VowelSounds {
 #define Z_LAYERING      1
 
 // Button Input
-#define BUTTON_PIN 33
+#define BUTTON_PIN 32 //33
 
 // MAX - MIN | Freq Volume
 #define MAX_FREQUENCY       4000.0

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -293,21 +293,14 @@ void setup_rotary_encoder(){
     rotaryEncoder.disableAcceleration();
 }
 
-/// @brief Calculates the pattern index the rotary encoder currently
-/// corresponds to.
-/// @returns The pattern index the encoder is set to.
-int calculate_pattern_index(){
-    return static_cast<int>(floor(rotaryEncoder.readEncoder())) % NUM_PATTERNS;
-}
-
 /// @brief Returns the current state of the rotary encoder button.
 /// @returns True if pressed, false if not.
 bool isEncoderButtonPressed(){
     return rotaryEncoder.isEncoderButtonClicked();
 }
 
-/// @brief Sets the rotary encoder's current position to a new value.
-/// @param newValue The new index value that the rotary encoder is set to.
-void update_encoder_value(long newValue) {
-  rotaryEncoder.setEncoderValue(newValue);
+/// @brief Returns the difference between the encoder's previous and new position.
+/// @return An integer representing the change in the encoder's position.
+int encoder_delta(){
+  return static_cast<int>(floor(rotaryEncoder.encoderChanged())) % NUM_PATTERNS;
 }

--- a/main/nanolux_util.cpp
+++ b/main/nanolux_util.cpp
@@ -289,8 +289,8 @@ void IRAM_ATTR readEncoderISR(){
 void setup_rotary_encoder(){
     rotaryEncoder.begin();
     rotaryEncoder.setup(readEncoderISR);
-    rotaryEncoder.setBoundaries(0, 1000, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
-    rotaryEncoder.setAcceleration(0);
+    rotaryEncoder.setBoundaries(0, NUM_PATTERNS - 1, true); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
+    rotaryEncoder.disableAcceleration();
 }
 
 /// @brief Calculates the pattern index the rotary encoder currently
@@ -304,4 +304,10 @@ int calculate_pattern_index(){
 /// @returns True if pressed, false if not.
 bool isEncoderButtonPressed(){
     return rotaryEncoder.isEncoderButtonClicked();
+}
+
+/// @brief Sets the rotary encoder's current position to a new value.
+/// @param newValue The new index value that the rotary encoder is set to.
+void update_encoder_value(long newValue) {
+  rotaryEncoder.setEncoderValue(newValue);
 }

--- a/main/nanolux_util.h
+++ b/main/nanolux_util.h
@@ -21,8 +21,7 @@ void process_reset_button(int button_value);
 void nanolux_serial_print(char * msg);
 void IRAM_ATTR readEncoderISR();
 void setup_rotary_encoder();
-int calculate_pattern_index();
 bool isEncoderButtonPressed();
-void update_encoder_value(long newValue);
+int encoder_delta();
 
 #endif

--- a/main/nanolux_util.h
+++ b/main/nanolux_util.h
@@ -23,5 +23,6 @@ void IRAM_ATTR readEncoderISR();
 void setup_rotary_encoder();
 int calculate_pattern_index();
 bool isEncoderButtonPressed();
+void update_encoder_value(long newValue);
 
 #endif

--- a/main/webServer.h
+++ b/main/webServer.h
@@ -17,7 +17,7 @@
 #define ALWAYS_PRINTF(...) Serial.printf(__VA_ARGS__)
 
 // Uncomment to use the old LittleFS web app loader.
-//#define SD_LOADER
+#define SD_LOADER
 
 #ifdef SD_LOADER
   #include "FS.h"


### PR DESCRIPTION
This PR resolves issue #90 and includes changes to the web app to implement bidirectional communication between the web app and hardware.

- The rotary encoder no longer reads and sends index values to the ESP32. Instead, a position delta is read from the encoder (encoderDelta).
- manual_pattern has been removed from hardware logic as the encoder now updates the first loaded_patterns index directly using a delta value read from the encoder.
- Logic to switch between manual_pattern and loaded_patterns has been removed from the main loop as manual_pattern is no longer used.
- The pattern_settings component of the web app now continuously polls the hardware for updates to the pattern data in loaded_patterns and updates the UI list to display the current pattern being output (specifically for pattern index changes stemming from the rotary encoder).